### PR TITLE
Fix unexpected exit code on darwin

### DIFF
--- a/update-formula.sh
+++ b/update-formula.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-d="$( cd "$(dirname "$0")"; pwd )"
 
 VERSION=$1
 if [ "$VERSION" == "" ]; then

--- a/update-formula.sh
+++ b/update-formula.sh
@@ -14,19 +14,9 @@ fi
     SHA256_LINUX_64=$(curl -s -L "https://github.com/soracom/soracom-cli/releases/download/v$VERSION/soracom_${VERSION}_linux_amd64" | shasum -a 256 | cut -f 1 -d ' ' )
 }
 
-os="$( uname -s )"
-[[ "$os" == "Darwin" ]] && {
-  sed -e "s/VERSION *=.*/VERSION = \"$VERSION\"/g"       -i '.bak' soracom-cli.rb
-  sed -e "s/SHA256_MAC_32 *=.*/SHA256_MAC_32 = \"$SHA256_MAC_32\"/g" -i '.bak' soracom-cli.rb
-  sed -e "s/SHA256_MAC_64 *=.*/SHA256_MAC_64 = \"$SHA256_MAC_64\"/g" -i '.bak' soracom-cli.rb
-  sed -e "s/SHA256_LINUX_32 *=.*/SHA256_LINUX_32 = \"$SHA256_LINUX_32\"/g" -i '.bak' soracom-cli.rb
-  sed -e "s/SHA256_LINUX_64 *=.*/SHA256_LINUX_64 = \"$SHA256_LINUX_64\"/g" -i '.bak' soracom-cli.rb
-}
-[[ "$os" == "Linux" ]] && {
-  sed -e "s/VERSION *=.*/VERSION = \"$VERSION\"/g"       -i'.bak' soracom-cli.rb
-  sed -e "s/SHA256_MAC_32 *=.*/SHA256_MAC_32 = \"$SHA256_MAC_32\"/g" -i'.bak' soracom-cli.rb
-  sed -e "s/SHA256_MAC_64 *=.*/SHA256_MAC_64 = \"$SHA256_MAC_64\"/g" -i'.bak' soracom-cli.rb
-  sed -e "s/SHA256_LINUX_32 *=.*/SHA256_LINUX_32 = \"$SHA256_LINUX_32\"/g" -i'.bak' soracom-cli.rb
-  sed -e "s/SHA256_LINUX_64 *=.*/SHA256_LINUX_64 = \"$SHA256_LINUX_64\"/g" -i'.bak' soracom-cli.rb
-}
+sed -e "s/VERSION *=.*/VERSION = \"$VERSION\"/g"       -i'.bak' soracom-cli.rb
+sed -e "s/SHA256_MAC_32 *=.*/SHA256_MAC_32 = \"$SHA256_MAC_32\"/g" -i'.bak' soracom-cli.rb
+sed -e "s/SHA256_MAC_64 *=.*/SHA256_MAC_64 = \"$SHA256_MAC_64\"/g" -i'.bak' soracom-cli.rb
+sed -e "s/SHA256_LINUX_32 *=.*/SHA256_LINUX_32 = \"$SHA256_LINUX_32\"/g" -i'.bak' soracom-cli.rb
+sed -e "s/SHA256_LINUX_64 *=.*/SHA256_LINUX_64 = \"$SHA256_LINUX_64\"/g" -i'.bak' soracom-cli.rb
 


### PR DESCRIPTION
`[[ "$os" == "Linux" ]]`の評価結果が本スクリプトの  exit code となりMacOS上で実行すると期待と異なる結果になる。

MacOS(Catalina)のsedマニュアルでは`-i`オプションの後ろにスペースがあるよう書きぶりですが、スペースがなくても動作しましたので、シンプルに`-i`の後ろのスペースを削除する事に統一するのはいかがでしょうか？

MacOSのマニュアル
```
     -i extension
             Edit files in-place, saving backups with the specified extension.  If a zero-length extension is given, no backup will be saved.  It is not recommended to give a
             zero-length extension when in-place editing files, as you risk corruption or partial content in situations where disk space is exhausted, etc.
```

Ubuntuのマニュアル
```
       -i[SUFFIX], --in-place[=SUFFIX]
              edit files in place (makes backup if SUFFIX supplied)
```